### PR TITLE
let's store the app name

### DIFF
--- a/lib/rapns/daemon/apns/feedback_receiver.rb
+++ b/lib/rapns/daemon/apns/feedback_receiver.rb
@@ -64,7 +64,7 @@ module Rapns
           formatted_failed_at = failed_at.strftime("%Y-%m-%d %H:%M:%S UTC")
           Rapns.logger.info("[#{@app.name}] [FeedbackReceiver] Delivery failed at #{formatted_failed_at} for #{device_token}.")
 
-          feedback = Rapns::Daemon.store.create_apns_feedback(failed_at, device_token, @app)
+          feedback = Rapns::Daemon.store.create_apns_feedback(failed_at, device_token, @app.name)
           reflect(:apns_feedback, feedback)
 
           # Deprecated.


### PR DESCRIPTION
FR depends on being able to match the app name.

It appears the behavior here has changed over time.

Here are various values we've seen in our `rapns_feedback` table:
* `1	[device_token]	2012-10-26T19:00:17.000+00:00	2012-10-26T19:00:25.155+00:00	2012-10-26T19:00:25.155+00:00	client_booking_production`
* `6255	[device_token]	2015-07-03T00:01:15.000+00:00	2015-07-03T00:01:38.571+00:00	2015-07-03T00:01:38.571+00:00	5`
* `6256	[device_token]	2015-07-04T00:01:04.000+00:00	2015-07-04T00:01:06.581+00:00	2015-07-04T00:01:06.581+00:00	#<Rapns::Apns::App:0x007f69c7749770>`